### PR TITLE
Fix library locate

### DIFF
--- a/packages/orn-locator/src/resolvers/books.ts
+++ b/packages/orn-locator/src/resolvers/books.ts
@@ -63,7 +63,7 @@ const libraryData = (language: string) => {
 
 export const library = async(language: string = 'all') => {
   const bookIds = await getBookIds();
-  const contents: Book[] = (await asyncPool(2, bookIds, book)).filter((book: Book) =>
+  const contents: Book[] = (await asyncPool(2, bookIds, (bookId: string) => book(bookId))).filter((book: Book) =>
     (language === 'all' || book.language === language) && book.state === 'live'
   );
 


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2610

asyncPool passes the entire array as the second argument to the function so we need to wrap the book function so the array is not passed into the `version` optional argument.