### PR TITLE
Use ts-utils memoize instead of lodash's

### DIFF
--- a/packages/orn-locator/package.json
+++ b/packages/orn-locator/package.json
@@ -48,14 +48,12 @@
     "cross-fetch": "^3.1.5",
     "domutils": "^3.0.1",
     "htmlparser2": "^8.0.1",
-    "lodash": "^4.17.21",
     "node-fetch": "^2",
     "path-to-regexp": "^6.2.0",
     "tiny-async-pool": "1"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/lodash": "^4.14.186",
     "@types/node": "^17.0.35",
     "@types/node-fetch": "^2.6.2",
     "@types/tiny-async-pool": "1",

--- a/packages/orn-locator/src/resolvers/books.ts
+++ b/packages/orn-locator/src/resolvers/books.ts
@@ -1,5 +1,5 @@
+import { memoize } from '@openstax/ts-utils';
 import fetch from 'cross-fetch';
-import memoize from 'lodash/fp/memoize';
 import asyncPool from 'tiny-async-pool/lib/es6';
 import { isResourceOrContentOfTypeFilter } from '..';
 import { patterns } from '../ornPatterns';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3826,11 +3826,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash@^4.14.186":
-  version "4.14.194"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
-  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
-
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2523

This was causing a bunch of errors in search that were very annoying to track down because getArchiveInfo was sometimes returning wrong info.