### PR TITLE
Make sure to await resolveConfigValue()

### DIFF
--- a/packages/lambda/src/services/searchClient/searchClient.ts
+++ b/packages/lambda/src/services/searchClient/searchClient.ts
@@ -14,9 +14,9 @@ interface Initializer<C> {
 
 export const createSearchClient = <C extends string = 'search'>(initializer: Initializer<C>) => (configProvider: {[key in C]: ConfigProviderForConfig<Config>}) => {
   const config = configProvider[ifDefined(initializer.configSpace, 'search' as C)];
-  const searchHost = resolveConfigValue(config.searchHost);
+  const searchHost = once(() => resolveConfigValue(config.searchHost));
   const getSearchApi = once(async() => new SearchApi(new Configuration({
-    basePath: `${await searchHost}/api/v0`,
+    basePath: `${await searchHost()}/api/v0`,
     fetchApi: initializer.fetch,
   })));
 


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2651

Not awaiting resolveConfigValue causes intermittent errors in lambda (the execution is paused before the promise is resolved and the promise fails due to timeouts etc when the execution is resumed)