### PR TITLE
Check status code of archive and ORN API before attempting to parse JSON

### DIFF
--- a/packages/orn-locator/src/index.ts
+++ b/packages/orn-locator/src/index.ts
@@ -1,4 +1,4 @@
-import {locate, locateAll, search} from './lookup';
+import { locate, locateAll, search } from './lookup';
 import type { AnyOrnLocateResponse, SearchResponse } from './resolve';
 
 export { locate, locateAll, search };

--- a/packages/orn-locator/src/lookup.ts
+++ b/packages/orn-locator/src/lookup.ts
@@ -1,10 +1,12 @@
 import queryString from 'query-string';
 import type { AnyOrnLocateResponse, SearchResponse } from './resolve';
+import { acceptResponse } from './utils/acceptResponse';
 
 const locateHost = process.env.ORN_LOCATE_HOST || process.env.REACT_APP_ORN_LOCATE_HOST || 'https://orn.openstax.org';
 
 export const locate = async (orn: string): Promise<AnyOrnLocateResponse> => {
   return fetch(locateHost + (new URL(orn)).pathname + '.json')
+    .then(response => acceptResponse(response))
     .then(response => response.json());
 };
 
@@ -13,6 +15,7 @@ export const locateAll = async(orn: string[]): Promise<AnyOrnLocateResponse[]> =
     return Promise.resolve([]);
   }
   return fetch(locateHost + '/api/v0/orn-lookup?' + queryString.stringify({orn}))
+    .then(response => acceptResponse(response))
     .then(response => response.json())
     .then(response => response.items)
   ;
@@ -20,6 +23,7 @@ export const locateAll = async(orn: string[]): Promise<AnyOrnLocateResponse[]> =
 
 export const search = async(query: string, limit: number = 5, filters: {[key: string]: string | string[]} = {}): Promise<SearchResponse> => {
   return fetch(locateHost + '/api/v0/search?' + queryString.stringify({query, limit, ...filters}))
+    .then(response => acceptResponse(response))
     .then(response => response.json())
   ;
 };

--- a/packages/orn-locator/src/resolvers/books.ts
+++ b/packages/orn-locator/src/resolvers/books.ts
@@ -6,6 +6,7 @@ import fetch from 'cross-fetch';
 import asyncPool from 'tiny-async-pool/lib/es6';
 import { locateAll } from '../resolve';
 import type { SearchClient } from '../types/searchClient';
+import { acceptResponse } from '../utils/acceptResponse';
 import { TitleParts, titleSplit } from '../utils/browsersafe-title-split';
 
 const oswebUrl = 'https://openstax.org/apps/cms/api/v2/pages';
@@ -15,6 +16,7 @@ const preloadedData = (file: string) => import('../data/' + file);
 
 export const getReleaseJson = memoize(async () => preloadedData('release.json').catch(() => {
   return fetch('https://openstax.org/rex/release.json')
+    .then(response => acceptResponse(response))
     .then(response => response.json())
   ;
 }));
@@ -88,12 +90,14 @@ const archiveBook = async(bookId: string, bookContentVersion?: string, bookArchi
   return preloadedData(bookCacheKey(archivePath, bookId, bookVersion))
     .catch(() =>
       fetch(`https://openstax.org${archivePath}/contents/${bookId}@${bookVersion}.json`)
+        .then(response => acceptResponse(response))
         .then(response => response.json())
     );
 };
 
 const commonBook = memoize(async(id: string, version?: string, archive?: string) => {
   const oswebData = await fetch(`${oswebUrl}?type=books.Book&fields=${fields}&cnx_id=${id}`)
+    .then(response => acceptResponse(response))
     .then(response => response.json() as any)
     .then(data => data.items[0])
   ;
@@ -249,6 +253,7 @@ export const subbook = async(
   const {archivePath, bookVersion} = await getArchiveInfo(bookId, bookContentVersion, bookArchiveVersion);
   const archiveUrl = `https://openstax.org${archivePath}/contents/${bookId}@${bookVersion}.json`;
   const archiveData = await fetch(archiveUrl)
+    .then(response => acceptResponse(response))
     .then(response => response.json())
   ;
 
@@ -308,6 +313,7 @@ const pageWithData = async(
   const {archivePath, bookVersion} = await getArchiveInfo(bookId, bookContentVersion, bookArchiveVersion);
   const archiveUrl = `https://openstax.org${archivePath}/contents/${bookId}@${bookVersion}:${pageId}.json`;
   const archiveData = await fetch(archiveUrl)
+    .then(response => acceptResponse(response))
     .then(response => response.json())
   ;
 

--- a/packages/orn-locator/src/utils/acceptResponse.spec.ts
+++ b/packages/orn-locator/src/utils/acceptResponse.spec.ts
@@ -1,0 +1,40 @@
+import { InvalidRequestError, NotFoundError, UnauthorizedError } from '@openstax/ts-utils/errors';
+import { acceptResponse } from './acceptResponse';
+
+describe('acceptResponse', () => {
+  it('returns the response if the status code is in the allow list', async() => {
+    const okResponse = { status: 200, text: async() => 'OK' };
+    expect(await acceptResponse(okResponse)).toBe(okResponse);
+
+    const createdResponse = { status: 201, text: async() => 'Created' };
+    expect(await acceptResponse(createdResponse, [201])).toBe(createdResponse);
+  });
+
+  it('throws InvalidRequestError if the status code is 400', async() => {
+    const rejectedPromise = acceptResponse({ status: 400, text: async() => 'Invalid' });
+    await expect(rejectedPromise).rejects.toThrow(InvalidRequestError);
+    await expect(rejectedPromise).rejects.toThrow('Invalid');
+  });
+
+  it('throws UnauthorizedError if the status code is 401', async() => {
+    const rejectedPromise = acceptResponse({ status: 401, text: async() => 'Unauthorized' });
+    await expect(rejectedPromise).rejects.toThrow(UnauthorizedError);
+    await expect(rejectedPromise).rejects.toThrow('Unauthorized');
+  });
+
+  it('throws NotFoundError if the status code is 404', async() => {
+    const rejectedPromise = acceptResponse({ status: 404, text: async() => 'Not Found' });
+    await expect(rejectedPromise).rejects.toThrow(NotFoundError);
+    await expect(rejectedPromise).rejects.toThrow('Not Found');
+  });
+
+  it('throws Error if the status code is something else not expected', async() => {
+    const rejectedPromise1 = acceptResponse({ status: 200, text: async() => 'OK' }, [201]);
+    await expect(rejectedPromise1).rejects.toThrow(Error);
+    await expect(rejectedPromise1).rejects.toThrow('OK');
+
+    const rejectedPromise2 = acceptResponse({ status: 201, text: async() => 'Created' });
+    await expect(rejectedPromise2).rejects.toThrow(Error);
+    await expect(rejectedPromise2).rejects.toThrow('Created');
+  });
+});

--- a/packages/orn-locator/src/utils/acceptResponse.ts
+++ b/packages/orn-locator/src/utils/acceptResponse.ts
@@ -1,0 +1,19 @@
+import { InvalidRequestError, NotFoundError, UnauthorizedError } from '@openstax/ts-utils/errors';
+
+type ResponseLike = { status: number; text: () => Promise<string> };
+
+export const acceptResponse = async<T extends ResponseLike>(response: T, statusCodes?: number[]) => {
+  if ((statusCodes ?? [200]).includes(response.status)) { return response; }
+
+  const message = await response.text();
+  switch (response.status) {
+    case 400:
+      throw new InvalidRequestError(message);
+    case 401:
+      throw new UnauthorizedError(message);
+    case 404:
+      throw new NotFoundError(message);
+    default:
+      throw new Error(message);
+  }
+};


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2706

So with this change I get a proper 404 response when trying to load a page that doesn't exist like https://localhost:3000/orn/book:page/a7ba2fb8-8925-4987-b182-5f4429d48daa:1ee00ee2-3fa6-439a-86da-af3582fb46bc.json

However, the response contains html (I think the 404 html from archive) rather than JSON. Which may be the right thing anyway, I'm not sure. I guess that's what archive does for a 404...