### PR TITLE
Bump orn-locator version

### DIFF
--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@openstax/open-search-client": "^0.1.0-build.8",
-    "@openstax/orn-locator": "^1.1.22",
+    "@openstax/orn-locator": "^1.2.5",
     "@openstax/ts-utils": "1.2.0",
     "aws-sdk": "^2.1145.0",
     "body-parser": "^1.19.2",

--- a/packages/orn-locator/package.json
+++ b/packages/orn-locator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/orn-locator",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "main": "dist/index.nodejs.js",
   "browser": "dist/index.browser.js",
   "types": "index.d.ts",


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2649

I realized I hadn't released the changes from https://github.com/openstax/openstax-resource-names/pull/19.