### PR TITLE
DISCO-213 Fixed CloudFront caching

### DIFF
--- a/deploy/deployment.cfn.yml
+++ b/deploy/deployment.cfn.yml
@@ -82,7 +82,7 @@ Resources:
       MemorySize: 512
       Timeout: 30 # logging stacktraces is surprisingly heavy
       Role: !GetAtt lambdaIAMRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           API_HOST: !Sub

--- a/deploy/deployment.cfn.yml
+++ b/deploy/deployment.cfn.yml
@@ -353,15 +353,12 @@ Resources:
               - PUT
               - PATCH
             Compress: 'true'
-            DefaultTTL: 0
-            MaxTTL: 0
-            MinTTL: 0
+            DefaultTTL: 86400
+            MaxTTL: 86400
+            MinTTL: 86400
             ForwardedValues:
               Headers:
-                - Authorization
                 - Origin
-              Cookies:
-                Forward: all
               QueryString: true
             ViewerProtocolPolicy: redirect-to-https
 
@@ -381,10 +378,7 @@ Resources:
             MinTTL: 86400
             ForwardedValues:
               Headers:
-                - Authorization
                 - Origin
-              Cookies:
-                Forward: all
               QueryString: false
             ViewerProtocolPolicy: redirect-to-https
 


### PR DESCRIPTION
This should help at least a little bit with ORN performance.

- Set ORN API caching TTL to 1 day (same as the /orn/* routes)
- Remove forwarding and caching of Authorization header and cookies