### PR TITLE
DISCO-213 Use ES as an ORN cache

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "dependencies": {
-    "@openstax/orn-locator": "^1.2.5",
+    "@openstax/orn-locator": "^1.3.0",
     "@openstax/ts-utils": "1.8.0",
     "@openstax/ui-components": "https://github.com/openstax/ui-components#1.7.3",
     "@testing-library/jest-dom": "^5.14.1",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@openstax/open-search-client": "^0.1.0-build.8",
-    "@openstax/orn-locator": "^1.2.5",
+    "@openstax/orn-locator": "^1.3.0",
     "@openstax/ts-utils": "1.8.0",
     "aws-sdk": "^2.1145.0",
     "aws-xray-sdk": "^3.6.0",

--- a/packages/lambda/src/functions/serviceApi/versions/v0/routes/ornRoutes.ts
+++ b/packages/lambda/src/functions/serviceApi/versions/v0/routes/ornRoutes.ts
@@ -11,14 +11,14 @@ const requestServiceProvider = composeServiceMiddleware(searchMiddleware);
 export const apiV0LookupOrns = createRoute({name: 'apiV0LookupOrns', method: METHOD.GET, path: '/api/v0/orn-lookup',
   requestServiceProvider},
   async(_params: undefined, services) => {
+    const { orn, skipCache } = services.request.queryStringParameters ?? {};
     const options = {
       concurrency: 10,
       searchClient: services.searchClient,
-      skipCache: services.request.queryStringParameters?.skipCache === 'true',
+      skipCache: skipCache === 'true',
     };
     const orns = assertDefined(
-      services.request.queryStringParameters?.orn,
-      new InvalidRequestError('an orn query parameter is required')
+      orn, new InvalidRequestError('an orn query parameter is required')
     ).split(',');
 
     const items = await locateAll(options, orns);
@@ -32,7 +32,7 @@ export const apiV0LookupOrns = createRoute({name: 'apiV0LookupOrns', method: MET
 export const apiV0Search = createRoute({name: 'apiV0Search', method: METHOD.GET, path: '/api/v0/search',
   requestServiceProvider},
   async(_params: undefined, services) => {
-    const {query: rawQuery, limit: rawLimit, type} = services.request.queryStringParameters || {};
+    const {query: rawQuery, limit: rawLimit, type} = services.request.queryStringParameters ?? {};
 
     const query = assertDefined(rawQuery, new InvalidRequestError('an query string is required'));
 

--- a/packages/lambda/src/functions/serviceApi/versions/v0/routes/ornRoutes.ts
+++ b/packages/lambda/src/functions/serviceApi/versions/v0/routes/ornRoutes.ts
@@ -1,4 +1,4 @@
-// spell-checker: ignore Orns 
+// spell-checker: ignore Orns
 import { locate, locateAll, search } from '@openstax/orn-locator/resolve';
 import { assertDefined, assertNotNaN } from '@openstax/ts-utils/assertions';
 import { InvalidRequestError } from '@openstax/ts-utils/errors';
@@ -6,17 +6,22 @@ import { apiJsonResponse, apiTextResponse, METHOD } from '@openstax/ts-utils/rou
 import { composeServiceMiddleware, createRoute } from '../../../core/services';
 import { searchMiddleware } from '../middleware/searchMiddleware';
 
-const requestServiceProvider = composeServiceMiddleware();
+const requestServiceProvider = composeServiceMiddleware(searchMiddleware);
 
 export const apiV0LookupOrns = createRoute({name: 'apiV0LookupOrns', method: METHOD.GET, path: '/api/v0/orn-lookup',
   requestServiceProvider},
   async(_params: undefined, services) => {
+    const options = {
+      concurrency: 10,
+      searchClient: services.searchClient,
+      skipCache: services.request.queryStringParameters?.skipCache === 'true',
+    };
     const orns = assertDefined(
       services.request.queryStringParameters?.orn,
       new InvalidRequestError('an orn query parameter is required')
     ).split(',');
 
-    const items = await locateAll(orns, {concurrency: 10});
+    const items = await locateAll(options, orns);
 
     return apiJsonResponse(200, {
       items
@@ -25,10 +30,7 @@ export const apiV0LookupOrns = createRoute({name: 'apiV0LookupOrns', method: MET
 );
 
 export const apiV0Search = createRoute({name: 'apiV0Search', method: METHOD.GET, path: '/api/v0/search',
-  requestServiceProvider: composeServiceMiddleware(
-    requestServiceProvider,
-    searchMiddleware,
-  )},
+  requestServiceProvider},
   async(_params: undefined, services) => {
     const {query: rawQuery, limit: rawLimit, type} = services.request.queryStringParameters || {};
 
@@ -45,18 +47,26 @@ export const apiV0Search = createRoute({name: 'apiV0Search', method: METHOD.GET,
 
 export const apiV0LookupOrn = createRoute({name: 'apiV0LookupOrn', method: METHOD.GET, path: '/orn/:tail(.*?).json',
   requestServiceProvider},
-  async({tail}: {tail: string}) => {
+  async({tail}: {tail: string}, services) => {
+    const options = {
+      searchClient: services.searchClient,
+      skipCache: services.request.queryStringParameters?.skipCache === 'true',
+    };
     const orn = `https://openstax.org/orn/${tail}`;
-    const data = await locate(orn);
+    const data = await locate(options, orn);
     return apiJsonResponse(200, data);
   }
 );
 
 export const apiV0GoToOrn = createRoute({name: 'apiV0GoToOrn', method: METHOD.GET, path: '/orn/:tail(.*?)',
   requestServiceProvider},
-  async({tail}: {tail: string}) => {
+  async({tail}: {tail: string}, services) => {
+    const options = {
+      searchClient: services.searchClient,
+      skipCache: services.request.queryStringParameters?.skipCache === 'true',
+    };
     const orn = `https://openstax.org/orn/${tail}`;
-    const data = await locate(orn);
+    const data = await locate(options, orn);
 
     if (!('urls' in data)) {
       return apiTextResponse(400, 'this resource doesn\'t seem to be visitable');

--- a/packages/orn-locator/package.json
+++ b/packages/orn-locator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/orn-locator",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "browser": "dist/index.browser.js",
   "dependencies": {
     "@openstax/open-search-client": "^0.1.0-build.8",

--- a/packages/orn-locator/src/resolve.ts
+++ b/packages/orn-locator/src/resolve.ts
@@ -2,20 +2,36 @@ import asyncPool from 'tiny-async-pool/lib/es6';
 import { patterns } from './ornPatterns';
 import type { SearchClient } from './types/searchClient';
 
-export const locate = async (orn: string) => {
+export type LocateOptions = {
+  searchClient: SearchClient;
+  skipCache?: boolean;
+};
+
+export type LocateAllOptions = LocateOptions & { concurrency?: number };
+
+export const locate = async (options: LocateOptions, orn: string) => {
+  const useCache = options.searchClient && !options.skipCache;
+
   for (const pattern of Object.values(patterns)) {
     const match = pattern.match(orn);
 
     if (match) {
-      return await pattern.resolve(match.params);
+      if (useCache && pattern.cacheable && pattern.search) {
+        const cachedResult = await pattern.search(options.searchClient, orn, 1, 's2');
+        if (cachedResult) { return cachedResult[0]; }
+      }
+      return pattern.resolve(match.params);
     }
   }
 
-  return {type: 'not-found', orn} as const;
+  return {type: 'not-found', orn};
 };
 
-export const locateAll = async(orn: string[], {concurrency = 2}: {concurrency?: number} = {}): Promise<AnyOrnLocateResponse[]> => {
-  return await asyncPool(concurrency, orn, locate);
+export const locateAll = async(
+  {concurrency = 2, ...options}: LocateAllOptions, orn: string[]
+): Promise<AnyOrnLocateResponse[]> => {
+  const boundLocate = locate.bind(null, options);
+  return await asyncPool(concurrency, orn, boundLocate);
 };
 
 type Patterns = typeof patterns;

--- a/packages/orn-locator/src/resolve.ts
+++ b/packages/orn-locator/src/resolve.ts
@@ -18,7 +18,7 @@ export const locate = async (options: LocateOptions, orn: string) => {
     if (match) {
       if (useCache && pattern.cacheable && pattern.search) {
         const cachedResult = await pattern.search(options.searchClient, orn, 1, 's2');
-        if (cachedResult) { return cachedResult[0]; }
+        if (cachedResult[0]) { return cachedResult[0]; }
       }
       return pattern.resolve(match.params);
     }


### PR DESCRIPTION
Use ES as the ORN cache for book and page ORNs.

Testing needed.