### PR TITLE
bump ts utils again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5223,7 +5223,7 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
-      "peer": true,
+      "devOptional": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -11019,18 +11019,6 @@
       "version": "4.2.0",
       "license": "MIT"
     },
-    "node_modules/postgres": {
-      "version": "3.4.9",
-      "license": "Unlicense",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/porsager"
-      }
-    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "license": "MIT",
@@ -12017,7 +12005,7 @@
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
-      "peer": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -13910,6 +13898,7 @@
         "@types/node-fetch": "^2.6.11",
         "@types/supertest": "^2.0.12",
         "builtin-modules": "^3.2.0",
+        "busboy": "^1.6.0",
         "cspell": "^10.0.0",
         "eslint": "^9.39.1",
         "eslint-plugin-import-x": "^4.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@openstax/ts-utils": "1.50.0"
+        "@openstax/ts-utils": "1.50.2"
       },
       "devDependencies": {
         "syncpack": "^15.1.2"
@@ -2672,21 +2672,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@opensearch-project/opensearch": {
-      "version": "1.2.0",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "aws4": "^1.11.0",
-        "debug": "^4.3.1",
-        "hpagent": "^0.1.1",
-        "ms": "^2.1.3",
-        "secure-json-parse": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@openstax/open-search-client": {
       "version": "0.1.0-build.8",
       "license": "MIT"
@@ -2696,7 +2681,9 @@
       "link": true
     },
     "node_modules/@openstax/ts-utils": {
-      "version": "1.50.0",
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@openstax/ts-utils/-/ts-utils-1.50.2.tgz",
+      "integrity": "sha512-LEnDRvtbdjyeHxPq6XoXE3bZoSh0kbfPAWb7zI24O5mErqadNIGDwmIs7puxx68T6LDnoqEkx7HBGM7b99EvNA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.171.0",
@@ -2714,6 +2701,7 @@
         "js-sha1": "^0.7.0",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.3",
         "path-to-regexp": "^6.2.0",
         "query-string": "^7.1.1",
@@ -2724,10 +2712,24 @@
         "ts-utils": "script/bin-entry.bash"
       },
       "peerDependencies": {
-        "@opensearch-project/opensearch": "^1.2.0",
+        "@opensearch-project/opensearch": "^3.6.0",
         "busboy": "^1.6.0",
         "postgres": "^3.4.5",
         "zod": "^4.0.15"
+      },
+      "peerDependenciesMeta": {
+        "@opensearch-project/opensearch": {
+          "optional": true
+        },
+        "busboy": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@openstax/ui-components": {
@@ -4905,11 +4907,6 @@
       "peerDependencies": {
         "aws-xray-sdk-core": "^3.12.0"
       }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -7452,11 +7449,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/hpagent": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "dev": true,
@@ -9928,6 +9920,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "license": "MIT"
@@ -11658,11 +11656,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -13807,7 +13800,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@openstax/orn-locator": "^1.4.1",
-        "@openstax/ts-utils": "1.50.0",
+        "@openstax/ts-utils": "1.50.2",
         "@openstax/ui-components": "github:openstax/ui-components#1.23.0",
         "@testing-library/jest-dom": "^6.4.7",
         "@testing-library/react": "^16.3.2",
@@ -13900,7 +13893,7 @@
       "dependencies": {
         "@openstax/open-search-client": "^0.1.0-build.8",
         "@openstax/orn-locator": "^1.4.1",
-        "@openstax/ts-utils": "1.50.0",
+        "@openstax/ts-utils": "1.50.2",
         "aws-xray-sdk": "^3.6.0",
         "body-parser": "^1.19.2",
         "node-fetch": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@project/template",
   "version": "1.0.0",
   "dependencies": {
-    "@openstax/ts-utils": "1.50.0"
+    "@openstax/ts-utils": "1.50.2"
   },
   "devDependencies": {
     "syncpack": "^15.1.2"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@openstax/orn-locator": "^1.4.1",
-    "@openstax/ts-utils": "1.50.0",
+    "@openstax/ts-utils": "1.50.2",
     "@openstax/ui-components": "github:openstax/ui-components#1.23.0",
     "@testing-library/jest-dom": "^6.4.7",
     "@testing-library/react": "^16.3.2",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@openstax/open-search-client": "^0.1.0-build.8",
     "@openstax/orn-locator": "^1.4.1",
-    "@openstax/ts-utils": "1.50.0",
+    "@openstax/ts-utils": "1.50.2",
     "aws-xray-sdk": "^3.6.0",
     "body-parser": "^1.19.2",
     "node-fetch": "^2.7.0",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -21,6 +21,7 @@
     "@types/node-fetch": "^2.6.11",
     "@types/supertest": "^2.0.12",
     "builtin-modules": "^3.2.0",
+    "busboy": "^1.6.0",
     "cspell": "^10.0.0",
     "eslint": "^9.39.1",
     "eslint-plugin-import-x": "^4.15.0",


### PR DESCRIPTION
turns out npm installs peer dependencies by default, new version of ts-utils fixes it